### PR TITLE
firebaseのSDK初期化の方法を変更

### DIFF
--- a/app/_common/libs/firebase/admin.ts
+++ b/app/_common/libs/firebase/admin.ts
@@ -5,7 +5,11 @@ const serviceAccount = require('@/firebaseSecretKey.json')
 export const firebaseAdmin =
   getApps()[0] ??
   initializeApp({
-    credential: cert(serviceAccount),
+    credential: cert({
+      projectId: process.env.FIREBASE_PROJECT_ID,
+      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      privateKey: process.env.FIREBASE_PRIVATE_KEY!.replace(/\\n/g, '\n'),
+    }),
   })
 
 export const auth = getAuth()


### PR DESCRIPTION
firebase認証のSDK初期化方法をjsonファイルで認証するのではなく、環境変数での認証に変更