### PR TITLE
お気に入りに登録している投稿を出力。ビルドされるファイルが全てLambdaだったのを修正

### DIFF
--- a/app/_common/types/index.ts
+++ b/app/_common/types/index.ts
@@ -26,6 +26,8 @@ export type Factory = {
   id: string
   createdAt: string
   updatedAt: string
+  title: string
+  description: string
   name: string
   zipcode: string
   prefecture: string
@@ -55,16 +57,16 @@ export type Feature = {
 
 export type GenreToFactory = {
   genreId: string
-  genre: Genre
   factoryId: string
-  factory: Factory
+  genre: Genre
+  // factory: Factory
 }
 
 export type FactoryFeature = {
   featureId: string
-  feature: Feature
   factoryId: string
-  factory: Factory
+  feature: Feature
+  // factory: Factory
 }
 
 export type Favorite = {

--- a/app/_components/layouts/bottomNavigation/index.tsx
+++ b/app/_components/layouts/bottomNavigation/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import Link from 'next/link'
 import React from 'react'
 import {
@@ -5,11 +6,11 @@ import {
   HomeIcon,
   BuildingLibraryIcon,
 } from '@heroicons/react/24/outline'
-import { signIn } from 'next-auth/react'
+import { signIn, useSession } from 'next-auth/react'
 import LoginButton from '../../ui-parts/authButton/loginButton'
 import { getServerSession } from 'next-auth'
-const BottomNavigation = async () => {
-  const session = await getServerSession()
+const BottomNavigation = () => {
+  const session = useSession()
 
   return (
     <div className="hidden sm:block fixed bottom-0 left-0 w-full">
@@ -37,7 +38,7 @@ const BottomNavigation = async () => {
           </Link>
         </li>
         <li>
-          {session?.user ? (
+          {session?.data?.user ? (
             <Link
               href={'/dashboard'}
               className="flex flex-col justify-center items-center gap-1 p-3 rounded-md transition  hover:bg-color-main-200 text-xs h-full"

--- a/app/_components/layouts/header/index.tsx
+++ b/app/_components/layouts/header/index.tsx
@@ -1,5 +1,5 @@
+'use client'
 import React from 'react'
-import { signIn, signOut } from 'next-auth/react' // 1⃣
 import Link from 'next/link'
 import SideMenu from '../sideMenu'
 import {
@@ -10,8 +10,9 @@ import {
 import LoginButton from '../../ui-parts/authButton/loginButton'
 import LogoutButton from '../../ui-parts/authButton/logoutButton'
 import { getServerSession } from 'next-auth'
-const Header = async () => {
-  const session = await getServerSession()
+import { useSession } from 'next-auth/react'
+const Header = () => {
+  const session = useSession()
   return (
     <header className="flex items-center py-6 px-6 shadow-sm">
       <div className="">
@@ -47,7 +48,7 @@ const Header = async () => {
           </Link>
         </li>
         <li>
-          {session?.user ? (
+          {session?.data?.user ? (
             <Link
               href={'/dashboard'}
               className="flex items-center gap-2 p-3 rounded-md transition  hover:bg-color-main-200 "

--- a/app/_features/factory/api/index.ts
+++ b/app/_features/factory/api/index.ts
@@ -4,19 +4,18 @@ import { cookies } from 'next/headers'
 
 export const getAllFactory = async (): Promise<Factory[]> => {
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/factory`, {
-      credentials: 'include',
-    })
+    const res = await fetch(`${process.env.API_URL}/factory`)
     const factories = await res.json()
+
     return factories
   } catch (error: any) {
     throw new Error(error)
   }
 }
 
-export const getFactoryById = async (id: string) => {
+export const getFactoryById = async (id: string): Promise<Factory> => {
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/factory/${id}`)
+    const res = await fetch(`${process.env.API_URL}/factory/${id}`)
     const factory = await res.json()
     return factory
   } catch (error: any) {
@@ -34,7 +33,7 @@ export const createFactory = async (
     const bearer = theme?.value
     console.log(bearer)
 
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/factory`, {
+    const res = await fetch(`${process.env.API_URL}/factory`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/app/_features/factory/components/factoryItem.tsx
+++ b/app/_features/factory/components/factoryItem.tsx
@@ -13,9 +13,16 @@ type Props = {
 }
 
 const FactoryItem: FC<Props> = async ({ factory }) => {
-  const { id, name, zipcode, prefecture, city, addressDetail, imageUrl } =
-    factory
-  const genres = await getFactoryGenres(id)
+  const {
+    id,
+    name,
+    zipcode,
+    prefecture,
+    city,
+    addressDetail,
+    imageUrl,
+    genres,
+  } = factory
   const reviews = await getReviewsByFactoryId(id)
 
   return (
@@ -42,10 +49,10 @@ const FactoryItem: FC<Props> = async ({ factory }) => {
             <ul className="flex gap-1 mt-2">
               {genres.map((genre) => (
                 <li
-                  key={genre.id}
+                  key={genre.genre.id}
                   className="py-1 px-4 bg-slate-200 rounded-lg text-sm"
                 >
-                  #{genre.name}
+                  #{genre.genre.name}
                 </li>
               ))}
             </ul>

--- a/app/_features/factory/components/factoryList.tsx
+++ b/app/_features/factory/components/factoryList.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react'
 import { getAllFactory } from '../api'
 import FactoryItem from './factoryItem'
 
-const FactoryList: FC = async () => {
+const FactoryList = async () => {
   const factories = await getAllFactory()
 
   return (
@@ -13,5 +13,4 @@ const FactoryList: FC = async () => {
     </ul>
   )
 }
-
 export default FactoryList

--- a/app/_features/favorite/api/index.ts
+++ b/app/_features/favorite/api/index.ts
@@ -28,3 +28,15 @@ export const getFavorite = async (userId: string, factoryId: string) => {
   if (!res.ok) return
   return await res.json()
 }
+export const getAllFavoriteByUserId = async (userId: string) => {
+  const authorization = authHeaderServerComponents()
+
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/favorite/user/?useId=${userId}`,
+    {
+      headers: { ...authorization },
+    }
+  )
+  if (!res.ok) return
+  return await res.json()
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,14 +1,9 @@
 'use client'
 
 import Container from '@/app/_components/layouts/container'
-import { NextApiRequest } from 'next'
-import { useEffect, useState } from 'react'
-import { useSession } from 'next-auth/react'
 import { useMutateAuth } from '@/app/_features/auth/hooks/useMutateAuth'
 
 const AuthLogin = () => {
-  const session = useSession()
-
   const { email, setEmail, password, setPassword, signIn, singUp, message } =
     useMutateAuth()
 

--- a/app/dashboard/factory/page.tsx
+++ b/app/dashboard/factory/page.tsx
@@ -1,7 +1,8 @@
+import FactoryList from '@/app/_features/factory/components/factoryList'
 import React from 'react'
 
-const DashboardFactory = () => {
-  return <div>DashboardFactory</div>
+const DashboardFactory = async () => {
+  return <FactoryList />
 }
 
 export default DashboardFactory

--- a/app/dashboard/favorite/loading.tsx
+++ b/app/dashboard/favorite/loading.tsx
@@ -1,0 +1,5 @@
+import Spinner from '@/app/_components/ui-parts/spinner'
+
+export default function Loading() {
+  return <Spinner />
+}

--- a/app/dashboard/favorite/page.tsx
+++ b/app/dashboard/favorite/page.tsx
@@ -1,7 +1,24 @@
-import React from 'react'
+import { Favorite } from '@/app/_common/types'
+import FactoryItem from '@/app/_features/factory/components/factoryItem'
+import { getAllFavoriteByUserId } from '@/app/_features/favorite/api'
+import { options } from '@/app/next-auth'
+import { getServerSession } from 'next-auth'
 
-const DashboardFavorite = () => {
-  return <div>DashboardFavorite</div>
+const DashboardFavorite = async () => {
+  const session = await getServerSession(options)
+  const userId = session?.user.id
+  const favoriteFactories = await getAllFavoriteByUserId(userId)
+
+  return (
+    <ul className="grid gap-4">
+      {favoriteFactories?.map((favoriteFactory: Favorite) => (
+        <FactoryItem
+          key={favoriteFactory.factory.id}
+          factory={favoriteFactory.factory}
+        />
+      ))}
+    </ul>
+  )
 }
 
 export default DashboardFavorite

--- a/app/dashboard/review/loading.tsx
+++ b/app/dashboard/review/loading.tsx
@@ -1,0 +1,5 @@
+import Spinner from '@/app/_components/ui-parts/spinner'
+
+export default function Loading() {
+  return <Spinner />
+}

--- a/app/factory/[id]/page.tsx
+++ b/app/factory/[id]/page.tsx
@@ -1,11 +1,6 @@
 import Map from '@/app/_components/ui-element/googleMap'
 import Spinner from '@/app/_components/ui-parts/spinner'
-import {
-  getAllFactory,
-  getFactoryById,
-  getFactoryFeatures,
-  getFactoryGenres,
-} from '@/app/_features/factory/api'
+import { getAllFactory, getFactoryById } from '@/app/_features/factory/api'
 import { FavoriteButton } from '@/app/_features/favorite/components/favoriteButtton'
 import { getReviewsByFactoryId } from '@/app/_features/review/api'
 import { UserIcon } from '@heroicons/react/24/outline'
@@ -20,9 +15,6 @@ export default async function FactoryDetail({
 }) {
   const factory = await getFactoryById(params.id)
   const reviews = await getReviewsByFactoryId(params.id)
-  const genres = await getFactoryGenres(params.id)
-  const features = await getFactoryFeatures(params.id)
-  const session = await getServerSession()
 
   const {
     id,
@@ -40,6 +32,8 @@ export default async function FactoryDetail({
     holidays,
     siteUrl,
     imageUrl,
+    genres,
+    features,
   } = factory
 
   // console.log(factory)
@@ -81,12 +75,12 @@ export default async function FactoryDetail({
           <div className="">
             {features && features.length > 0 && (
               <ul className="flex gap-1 mt-2">
-                {features.map((genre) => (
+                {features.map((feature) => (
                   <li
-                    key={genre.id}
+                    key={feature.feature.id}
                     className="py-1 px-4 bg-slate-200 rounded-lg text-sm"
                   >
-                    {genre.name}
+                    {feature.feature.name}
                   </li>
                 ))}
               </ul>
@@ -100,10 +94,10 @@ export default async function FactoryDetail({
               <ul className="flex gap-1 mt-2">
                 {genres.map((genre) => (
                   <li
-                    key={genre.id}
+                    key={genre.genre.id}
                     className="py-1 px-4 bg-slate-200 rounded-lg text-sm"
                   >
-                    #{genre.name}
+                    #{genre.genre.name}
                   </li>
                 ))}
               </ul>

--- a/app/factory/loading.tsx
+++ b/app/factory/loading.tsx
@@ -1,0 +1,5 @@
+import Spinner from '@/app/_components/ui-parts/spinner'
+
+export default function Loading() {
+  return <Spinner />
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import Footer from './_components/layouts/footer'
 import NextAuthProvider from './_features/auth/providers/NextAuth'
 import BottomNavigation from './_components/layouts/bottomNavigation'
 import TanstackProvider from './_common/provaiders/TanstackProvider'
+import Link from 'next/link'
 
 const inter = Inter({ subsets: ['latin'] })
 const notoSansJP = Noto_Sans_JP({ subsets: ['latin'] })
@@ -23,16 +24,17 @@ export default async function RootLayout({
   return (
     <html lang="ja">
       <body className={`${notoSansJP.className}`}>
-        <TanstackProvider>
-          <NextAuthProvider>
-            <div className="text-color-main-800">
-              <Header />
-              <main>{children}</main>
-              <BottomNavigation />
-              <Footer />
-            </div>
-          </NextAuthProvider>
-        </TanstackProvider>
+        {/* <TanstackProvider> */}
+        <NextAuthProvider>
+          <div className="text-color-main-800">
+            <Header />
+            <Link href={'/factory'}>factory</Link>
+            <main>{children}</main>
+            <BottomNavigation />
+            <Footer />
+          </div>
+        </NextAuthProvider>
+        {/* </TanstackProvider> */}
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
-export default function Home() {
+import { getAllFactory } from './_features/factory/api'
+
+export default async function Home() {
   return <main></main>
 }


### PR DESCRIPTION
##やったこと
‐お気に入りに登録している投稿をすべて取得し、表示する。
‐ビルドした際に、全てLambdaで出力されていたので、SSGで出力するように修正。原因はlayout.tsxでインポートしているheaderコンポーネントでcookieを使う処理を入れていたため、プロジェクト全体がno-storeになっていた。