### PR TITLE
wip 施設情報がないときの処理追加

### DIFF
--- a/app/_components/ui-parts/selector/AreaSelector.tsx
+++ b/app/_components/ui-parts/selector/AreaSelector.tsx
@@ -12,12 +12,7 @@ export const AreaSelector: FC = async () => {
         </span>
         地域
       </label>
-      <select
-        name="area"
-        id="area"
-        className="selector"
-        defaultValue={'東京都'}
-      >
+      <select name="area" id="area" className="selector">
         {prefectures?.map((prefecture) => (
           <option key={prefecture.id} value={prefecture.slug}>
             {prefecture.name}

--- a/app/_features/factory/api/getFactoryById.ts
+++ b/app/_features/factory/api/getFactoryById.ts
@@ -1,8 +1,15 @@
 import { Factory } from '@/app/_common/types'
 
-export const getFactoryById = async (id: string): Promise<Factory> => {
+export const getFactoryById = async (id: string): Promise<Factory | null> => {
   try {
     const res = await fetch(`${process.env.API_URL}/factory/${id}`)
+
+    /* 施設情報が見つからない場合はnullを返却
+    ※バックエンドのバリデーションでuuidでないとエラーを返すようにしているので400も含んでいる。要検討
+    */
+    if (res.status === 404 || res.status === 400) {
+      return null
+    }
     const factory = await res.json()
     return factory
   } catch (error: any) {

--- a/app/factory/[id]/page.tsx
+++ b/app/factory/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '@heroicons/react/24/outline'
 import Image from 'next/image'
 import Link from 'next/link'
+import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
 
 export default async function FactoryDetail({
@@ -19,7 +20,10 @@ export default async function FactoryDetail({
   params: { id: string }
 }) {
   const factory = await getFactoryById(params.id)
-  const reviews = await getReviewsByFactoryId(params.id)
+
+  if (!factory) {
+    return notFound()
+  }
 
   const {
     id,
@@ -39,6 +43,7 @@ export default async function FactoryDetail({
     imageUrl,
     genres,
     features,
+    reviews,
   } = factory
 
   return (


### PR DESCRIPTION
##やったこと
特定の施設情報を取得する際、施設情報がなかったらnotfoundをリターンするように修正。

##検討事項
バックエンドでuuidのかどうかを判定しているため、uuid以外だと404ではなく400が返却されてしまう。uuidのバリデーションはおそらくいらないのでバックエンド側の修正が必要か